### PR TITLE
 Always enable gpgcheck, skip repos, add type to rawhide .repo too

### DIFF
--- a/rpmfusion-nonfree-rawhide.repo
+++ b/rpmfusion-nonfree-rawhide.repo
@@ -4,6 +4,7 @@ name=RPM Fusion for Fedora Rawhide - Nonfree
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-rawhide&arch=$basearch
 enabled=1
 skip_if_unavailable=1
+type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-rawhide

--- a/rpmfusion-nonfree-rawhide.repo
+++ b/rpmfusion-nonfree-rawhide.repo
@@ -3,7 +3,8 @@ name=RPM Fusion for Fedora Rawhide - Nonfree
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/development/$basearch/os/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-rawhide&arch=$basearch
 enabled=1
-gpgcheck=0
+gpgcheck=1
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-rawhide
 
 [rpmfusion-nonfree-rawhide-debuginfo]
@@ -13,7 +14,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-rawhide-debu
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-rawhide
 
 [rpmfusion-nonfree-rawhide-source]
@@ -23,6 +24,6 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-rawhide-sour
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-rawhide
 

--- a/rpmfusion-nonfree-rawhide.repo
+++ b/rpmfusion-nonfree-rawhide.repo
@@ -3,6 +3,7 @@ name=RPM Fusion for Fedora Rawhide - Nonfree
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/development/$basearch/os/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-rawhide&arch=$basearch
 enabled=1
+skip_if_unavailable=1
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-rawhide
@@ -12,6 +13,7 @@ name=RPM Fusion for Fedora Rawhide - Nonfree - Debug
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/development/$basearch/os/debug/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-rawhide-debug&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -22,6 +24,7 @@ name=RPM Fusion for Fedora Rawhide - Nonfree - Source
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/development/source/SRPMS/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-rawhide-source&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1

--- a/rpmfusion-nonfree-updates-testing.repo
+++ b/rpmfusion-nonfree-updates-testing.repo
@@ -3,6 +3,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Test Updates
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/updates/testing/$releasever/$basearch/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-testing-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -13,6 +14,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Test Updates Debug
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/updates/testing/$releasever/$basearch/debug/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-testing-debug-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -23,6 +25,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Test Updates Source
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/updates/testing/$releasever/SRPMS/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-testing-source-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1

--- a/rpmfusion-nonfree-updates-testing.repo
+++ b/rpmfusion-nonfree-updates-testing.repo
@@ -5,7 +5,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-test
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-testing-debuginfo]
@@ -15,7 +15,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-test
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-testing-source]
@@ -25,6 +25,6 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-test
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 

--- a/rpmfusion-nonfree-updates.repo
+++ b/rpmfusion-nonfree-updates.repo
@@ -5,7 +5,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-rele
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-debuginfo]
@@ -15,7 +15,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-rele
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-source]
@@ -25,6 +25,6 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-rele
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 

--- a/rpmfusion-nonfree-updates.repo
+++ b/rpmfusion-nonfree-updates.repo
@@ -3,6 +3,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Updates
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/updates/$releasever/$basearch/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-released-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -13,6 +14,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Updates Debug
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/updates/$releasever/$basearch/debug/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-released-debug-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -23,6 +25,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Updates Source
 #baseurl=http://download1.rpmfusion.org/nonfree/fedora/updates/$releasever/SRPMS/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-released-source-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1

--- a/rpmfusion-nonfree.repo
+++ b/rpmfusion-nonfree.repo
@@ -6,7 +6,7 @@ enabled=0
 metadata_expire=14d
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-debuginfo]
@@ -17,7 +17,7 @@ enabled=0
 metadata_expire=7d
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-source]
@@ -28,6 +28,6 @@ enabled=0
 metadata_expire=7d
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 

--- a/rpmfusion-nonfree.repo
+++ b/rpmfusion-nonfree.repo
@@ -4,6 +4,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-$releasever&arch=$basearch
 enabled=0
 metadata_expire=14d
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -15,6 +16,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Debug
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-debug-$releasever&arch=$basearch
 enabled=0
 metadata_expire=7d
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -26,6 +28,7 @@ name=RPM Fusion for Fedora $releasever - Nonfree - Source
 metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-source-$releasever&arch=$basearch
 enabled=0
 metadata_expire=7d
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1


### PR DESCRIPTION
1. There is no reason to ever disable gpgcheck, so please have and keep it enabled. `repo_gpgcheck` works fine, and an additional layer of protection would not be amiss.

2. Works around a bug (or feature) in dnf where it will not update any package if a single repo fails to download. RPMFusion mirrors have been offline in the past, though not for long.

3. I guess this was a mistake, that the rawhide repo is the only one missing the `type=rpm-md` option.

PS: How do I get these changes to the Fedora 26, 25, 24(?) repos? Do I need to do anything for that?

PPS: Note that this pull request is very similar to rpmfusion/rpmfusion-free-release#1.