### PR TITLE
Add support for an EL8 next repo

### DIFF
--- a/rpmfusion-nonfree-next-testing.repo
+++ b/rpmfusion-nonfree-next-testing.repo
@@ -1,0 +1,33 @@
+[rpmfusion-nonfree-next-testing]
+name=RPM Fusion for EL 8 - Nonfree - Next Test
+#baseurl=http://download1.rpmfusion.org/nonfree/el/testing/next/8/$basearch/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-next-test-8&arch=$basearch
+enabled=0
+metadata_expire=6h
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-el-8
+
+[rpmfusion-nonfree-next-testing-debuginfo]
+name=RPM Fusion for EL 8 - Nonfree - Next Test Debug
+#baseurl=http://download1.rpmfusion.org/nonfree/el/testing/next/8/$basearch/debug/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-next-test-debug-8&arch=$basearch
+enabled=0
+metadata_expire=6h
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-el-8
+
+[rpmfusion-nonfree-next-testing-source]
+name=RPM Fusion for EL 8 - Nonfree - Next Test Source
+#baseurl=http://download1.rpmfusion.org/nonfree/el/testing/next/8/SRPMS/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-next-test-source-8&arch=$basearch
+enabled=0
+metadata_expire=6h
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-el-8
+

--- a/rpmfusion-nonfree-next.repo
+++ b/rpmfusion-nonfree-next.repo
@@ -1,0 +1,33 @@
+[rpmfusion-nonfree-next]
+name=RPM Fusion for EL 8 - Nonfree - Next
+#baseurl=http://download1.rpmfusion.org/nonfree/el/next/8/$basearch/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-next-8&arch=$basearch
+enabled=1
+metadata_expire=6h
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-el-8
+
+[rpmfusion-nonfree-next-debuginfo]
+name=RPM Fusion for EL 8 - Nonfree - Next Debug
+#baseurl=http://download1.rpmfusion.org/nonfree/el/next/8/$basearch/debug/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-next-debug-8&arch=$basearch
+enabled=0
+metadata_expire=6h
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-el-8
+
+[rpmfusion-nonfree-next-source]
+name=RPM Fusion for EL 8 - Nonfree - Next Source
+#baseurl=http://download1.rpmfusion.org/nonfree/el/next/8/SRPMS/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-next-source-8&arch=$basearch
+enabled=0
+metadata_expire=6h
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-el-8
+

--- a/rpmfusion-nonfree-release.spec
+++ b/rpmfusion-nonfree-release.spec
@@ -3,7 +3,7 @@
 
 Name:           rpmfusion-%{_repo}-release
 Version:        8
-Release:        0.2
+Release:        1
 Summary:        RPM Fusion (%{_repo}) Repository Configuration
 
 License:        BSD
@@ -97,8 +97,8 @@ install -d -m755 \
 %config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-next*.repo
 
 %changelog
-* Fri Jul 23 2021 Xavier Bachelot <xavier@bachelot.org> - 8-0.2
-- Create sub-package for next repo
+* Thu Nov 25 2021 Xavier Bachelot <xavier@bachelot.org> - 8-1
+- Create sub-package for next repos
 
 * Wed Jan 09 2019 Xavier Bachelot <xavier@bachelot.org> - 8-0.1
 - Release for EL-8.

--- a/rpmfusion-nonfree-release.spec
+++ b/rpmfusion-nonfree-release.spec
@@ -13,6 +13,7 @@ Source2:        rpmfusion-%{_repo}-updates.repo
 Source3:        rpmfusion-%{_repo}-updates-testing.repo
 Source5:        rpmfusion-%{_repo}-tainted.repo
 Source6:        rpmfusion-%{_repo}-next.repo
+Source7:        rpmfusion-%{_repo}-next-testing.repo
 BuildArch:      noarch
 
 Requires:       redhat-release >= %{version}
@@ -82,6 +83,7 @@ install -d -m755 \
     %{SOURCE3} \
     %{SOURCE5} \
     %{SOURCE6} \
+    %{SOURCE7} \
     %{buildroot}%{_sysconfdir}/yum.repos.d
 
 %files
@@ -92,7 +94,7 @@ install -d -m755 \
 %config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-tainted.repo
 
 %files next
-%config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-next.repo
+%config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-next*.repo
 
 %changelog
 * Fri Jul 23 2021 Xavier Bachelot <xavier@bachelot.org> - 8-0.2

--- a/rpmfusion-nonfree-release.spec
+++ b/rpmfusion-nonfree-release.spec
@@ -1,24 +1,24 @@
-#global repo free
-%global repo nonfree
+#global _repo free
+%global _repo nonfree
 
-Name:           rpmfusion-%{repo}-release
+Name:           rpmfusion-%{_repo}-release
 Version:        8
 Release:        0.1
-Summary:        RPM Fusion (%{repo}) Repository Configuration
+Summary:        RPM Fusion (%{_repo}) Repository Configuration
 
 License:        BSD
 URL:            http://rpmfusion.org
-Source0:        RPM-GPG-KEY-rpmfusion-%{repo}-el-8
-Source2:        rpmfusion-%{repo}-updates.repo
-Source3:        rpmfusion-%{repo}-updates-testing.repo
-Source5:        rpmfusion-%{repo}-tainted.repo
+Source0:        RPM-GPG-KEY-rpmfusion-%{_repo}-el-8
+Source2:        rpmfusion-%{_repo}-updates.repo
+Source3:        rpmfusion-%{_repo}-updates-testing.repo
+Source5:        rpmfusion-%{_repo}-tainted.repo
 BuildArch:      noarch
 
 Requires:       redhat-release >= %{version}
 Requires:       epel-release >= %{version}
 
 
-%if %{repo} == "nonfree"
+%if "%{_repo}" == "nonfree"
 Requires:       rpmfusion-free-release >= %{version}
 
 %description
@@ -41,15 +41,15 @@ packaging guidelines.
 %endif
 
 %package tainted
-Summary:        RPM Fusion %{repo} Tainted repo definition
+Summary:        RPM Fusion %{_repo} Tainted repo definition
 Requires:       %{name} = %{version}-%{release}
-%if %{repo} == "free"
+%if "%{_repo}" == "free"
 Obsoletes:      livna-release < 1:1-2
 Provides:       livna-release = 1:1-2
 %endif
 
 %description tainted
-This package provides the RPM Fusion %{repo} Tainted repo definitions.
+This package provides the RPM Fusion %{_repo} Tainted repo definitions.
 
 %prep
 echo "Nothing to prep"
@@ -76,10 +76,10 @@ install -d -m755 \
 
 %files
 %config %{_sysconfdir}/pki/rpm-gpg/*
-%config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{repo}-updates*.repo
+%config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-updates*.repo
 
 %files tainted
-%config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{repo}-tainted.repo
+%config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-tainted.repo
 
 %changelog
 * Wed Jan 09 2019 Xavier Bachelot <xavier@bachelot.org> - 8-0.1

--- a/rpmfusion-nonfree-release.spec
+++ b/rpmfusion-nonfree-release.spec
@@ -3,7 +3,7 @@
 
 Name:           rpmfusion-%{_repo}-release
 Version:        8
-Release:        0.1
+Release:        0.2
 Summary:        RPM Fusion (%{_repo}) Repository Configuration
 
 License:        BSD
@@ -12,6 +12,7 @@ Source0:        RPM-GPG-KEY-rpmfusion-%{_repo}-el-8
 Source2:        rpmfusion-%{_repo}-updates.repo
 Source3:        rpmfusion-%{_repo}-updates-testing.repo
 Source5:        rpmfusion-%{_repo}-tainted.repo
+Source6:        rpmfusion-%{_repo}-next.repo
 BuildArch:      noarch
 
 Requires:       redhat-release >= %{version}
@@ -51,6 +52,14 @@ Provides:       livna-release = 1:1-2
 %description tainted
 This package provides the RPM Fusion %{_repo} Tainted repo definitions.
 
+%package next
+Summary:        RPM Fusion %{_repo} Next repo definition
+Requires:       %{name} = %{version}-%{release}
+Recommends:     (%{name}-next if centos-stream-release)
+
+%description next
+This package provides the RPM Fusion %{_repo} Next repo definitions.
+
 %prep
 echo "Nothing to prep"
 
@@ -72,6 +81,7 @@ install -d -m755 \
     %{SOURCE2} \
     %{SOURCE3} \
     %{SOURCE5} \
+    %{SOURCE6} \
     %{buildroot}%{_sysconfdir}/yum.repos.d
 
 %files
@@ -81,7 +91,13 @@ install -d -m755 \
 %files tainted
 %config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-tainted.repo
 
+%files next
+%config(noreplace) %{_sysconfdir}/yum.repos.d/rpmfusion-%{_repo}-next.repo
+
 %changelog
+* Fri Jul 23 2021 Xavier Bachelot <xavier@bachelot.org> - 8-0.2
+- Create sub-package for next repo
+
 * Wed Jan 09 2019 Xavier Bachelot <xavier@bachelot.org> - 8-0.1
 - Release for EL-8.
 


### PR DESCRIPTION
Counterpart to the Free flavor.

See https://github.com/rpmfusion/rpmfusion-free-release/pull/8

Again, the infra is not ready for Next, so not to be merged, but may help someday.
